### PR TITLE
fix issue #4 - incorrect default OS values for Win 10

### DIFF
--- a/generate-cat-file.c
+++ b/generate-cat-file.c
@@ -755,8 +755,8 @@ int main(int argc, char ** argv)
 	char a_hash[16];
 	int i;
 
-	char *os_string = "7X64,8X64,10X64";
-	char *os_attr_string = "2:6.1,2:6.2,2:6.4";
+	char *os_string = "7X64,8X64,_v100_X64";
+	char *os_attr_string = "2:6.1,2:6.2,2:10.0";
 	char *hardware_id = "windrbd";
 	int nr_files;
 	char c;


### PR DESCRIPTION
win 8.1 is still skipped, but if needed below are the values for it

OS:
- `_v63` - Win 8.1 x32
- `_v63_X64` - Win 8.1 x64
- `_v63_Server_X64` - Win Server 2012 R2

OSAttr: `2:6.3`