### PR TITLE
Fix negative integers encoding

### DIFF
--- a/generate-cat-file.c
+++ b/generate-cat-file.c
@@ -545,11 +545,10 @@ size_t encode_tagged_data(char tag, void *s, size_t a_fn(void*, bool), bool writ
 
 size_t encode_algo(void *p, bool write)
 {
-	struct algo *a = p;
 	size_t length = 0;
 	
-	length += encode_known_oid_with_header(a->algo_oid, write);
-	//length += encode_known_oid_with_header(&datacache.oids->algo_oid, write);
+	//length += encode_known_oid_with_header(((struct algo*)p)->algo_oid, write);
+	length += encode_known_oid_with_header(&datacache.oids->algo_oid, write);
 	length += encode_null(write);
 	
 	return length;
@@ -562,13 +561,13 @@ size_t encode_algo_sequence(void *p, bool write)
 
 size_t encode_attribute_name_and_value(void *p, bool write)
 {
-	struct an_attribute *a = p;
-	size_t length;
-
-	length = encode_string_as_utf16_bmp(a->name, write);
+	struct an_attribute *attr = p;
+	size_t length = 0;
+	
+	length += encode_string_as_utf16_bmp(attr->name, write);
 	length += encode_integer(268500993, write);
-	length += encode_string_as_utf16(a->value, write);
-
+	length += encode_string_as_utf16(attr->value, write);
+	
 	return length;
 }
 
@@ -590,12 +589,12 @@ size_t encode_attribute(void *p, bool write)
 
 size_t encode_member_info(void *p, bool write)
 {
-	struct a_file *f = p;
-	size_t length;
-
-	length = encode_string_as_utf16_bmp(f->guid, write);
+	struct a_file *file = p;
+	size_t length = 0;
+	
+	length += encode_string_as_utf16_bmp(file->guid, write);
 	length += encode_integer(512, write);
-
+	
 	return length;
 }
 
@@ -761,11 +760,10 @@ size_t encode_files(void *p, bool write)
 
 size_t encode_catalog_list_member_oid(void *p, bool write)
 {
-	struct catalog_list_element *e = p;
 	size_t length = 0;
 	
-	length += encode_known_oid_with_header(e->catalog_list_member_oid, write);
-	//length += encode_known_oid_with_header(&datacache.oids->catalog_list_member_oid, write);
+	//length += encode_known_oid_with_header(((struct catalog_list_element*)p)->catalog_list_member_oid, write);
+	length += encode_known_oid_with_header(&datacache.oids->catalog_list_member_oid, write);
 	length += encode_null(write);
 	
 	return length;
@@ -773,10 +771,8 @@ size_t encode_catalog_list_member_oid(void *p, bool write)
 
 size_t encode_catalog_list_oid(void *p, bool write)
 {
-	struct catalog_list_element *e = p;
-	
-	return encode_known_oid_with_header(e->catalog_list_oid, write);
-	//return encode_known_oid_with_header(&datacache.oids->catalog_list_oid, write);
+	//return encode_known_oid_with_header(((struct catalog_list_element*)p)->catalog_list_oid, write);
+	return encode_known_oid_with_header(&datacache.oids->catalog_list_oid, write);
 }
 
 size_t encode_global_attributes2(void *p, bool write)

--- a/generate-cat-file.c
+++ b/generate-cat-file.c
@@ -726,10 +726,27 @@ size_t encode_file_attributes(void *p, bool write)
 	struct a_file *file = p;
 	size_t length = 0;
 	
+	/*
+	//initial order
 	length += encode_tagged_data(SEQUENCE_TAG, &file->file_attribute, encode_attribute, write);
 	length += encode_tagged_data(SEQUENCE_TAG, &file->os_attribute, encode_attribute, write);
 	length += encode_tagged_data(SEQUENCE_TAG, p, encode_spc_oid, write);
 	length += encode_tagged_data(SEQUENCE_TAG, p, encode_member_info_oid, write);
+	/*/
+	//Inf2Cat like order
+	length += encode_tagged_data(SEQUENCE_TAG, &file->os_attribute, encode_attribute, write);
+	length += encode_tagged_data(SEQUENCE_TAG, &file->file_attribute, encode_attribute, write);
+	if (file->is_link)
+	{
+		length += encode_tagged_data(SEQUENCE_TAG, p, encode_spc_oid, write);
+		length += encode_tagged_data(SEQUENCE_TAG, p, encode_member_info_oid, write);
+	}
+	else
+	{
+		length += encode_tagged_data(SEQUENCE_TAG, p, encode_member_info_oid, write);
+		length += encode_tagged_data(SEQUENCE_TAG, p, encode_spc_oid, write);
+	}
+	/**/
 	
 	return length;
 }

--- a/generate-cat-file.c
+++ b/generate-cat-file.c
@@ -701,54 +701,54 @@ size_t encode_member_info_oid(void *p, bool write)
 	return length;
 }
 
-size_t encode_obsolete_image_data(void *p, bool write)
-{
-	if (!write)
-		return 0x26;
-	
-	char image_data[0x26] = { 0x03, 0x02, 0x05, 0xA0, 0xA0, 0x20, 0xA2, 0x1E, 0x80, 0x1C, 0x00, 0x3C, 0x00, 0x3C, 0x00, 0x3C, 0x00, 0x4F, 0x00, 0x62, 0x00, 0x73, 0x00, 0x6F, 0x00, 0x6C, 0x00, 0x65, 0x00, 0x74, 0x00, 0x65, 0x00, 0x3E, 0x00, 0x3E, 0x00, 0x3E };
-//	char image_data[0x18] = { 0x03, 0x02, 0x05, 0xA0, 0xA0, 0x12, 0xA2, 0x10, 0x80, 0x0E, 0x00, 0x5A, 0x00, 0x61, 0x00, 0x6B, 0x00, 0x6C, 0x00, 0x65, 0x00, 0x62, 0x00, 0x74 };
-
-// 03 02 05 A0 A0 12 A2
-// 10 80 0E 00 7A 00 61 00  6B 00 6C 00 65 00 62 00
-// 74 30 21 30 09 06 05 2B
-// zaklebt: hacked catgen
-// 007A0061006B006C006500620074
-	
-	return append_to_buffer(sizeof(image_data), image_data);
-}
-
 size_t encode_spc_image_data(void *p, bool write)
 {
-	struct a_file *f = p;
-	size_t length;
+	size_t length = encode_known_oid_with_header(&datacache.oids->spc_image_data_oid, write);
 	
-	length = encode_known_oid_with_header(&datacache.oids->spc_image_data_oid, write);
-	length += encode_sequence(f, encode_obsolete_image_data, write);
+	//*
+	if (!write)
+		return length + 0x28;
 	
-	return length;
+	// <<<obsolete>>>: vanila         vv                                  vv          vv          vv |  value utf-16-bmp, to the end
+	char image_data[0x28] = { 0x30, 0x26, 0x03, 0x02, 0x05, 0xA0, 0xA0, 0x20, 0xA2, 0x1E, 0x80, 0x1C, 0x00, 0x3C, 0x00, 0x3C, 0x00, 0x3C, 0x00, 0x4F, 0x00, 0x62, 0x00, 0x73, 0x00, 0x6F, 0x00, 0x6C, 0x00, 0x65, 0x00, 0x74, 0x00, 0x65, 0x00, 0x3E, 0x00, 0x3E, 0x00, 0x3E };
+	
+	return 
+		length + append_to_buffer(sizeof(image_data), image_data);
+	/*/
+	if (!write)
+		return length + 0x1A;
+	
+	// zaklebt: hacked catgen         vv                                  vv          vv          vv |  value utf-16-bmp, to the end
+	char image_data[0x1A] = { 0x30, 0x18, 0x03, 0x02, 0x05, 0xA0, 0xA0, 0x12, 0xA2, 0x10, 0x80, 0x0E, 0x00, 0x5A, 0x00, 0x61, 0x00, 0x6B, 0x00, 0x6C, 0x00, 0x65, 0x00, 0x62, 0x00, 0x74 };
+	
+	return 
+		length + append_to_buffer(sizeof(image_data), image_data);
+	/**/
 }
 
 size_t encode_spc_link(void *p, bool write)
 {
 	size_t length = encode_known_oid_with_header(&datacache.oids->spc_link_oid, write);
 	
+	//*
 	if (!write)
-		return length + 0x12;
+		return length + 0x20;
 	
-/*	char link_data[0x20] = {
-		0xA2, 0x1E, 0x80, 0x1C, 0x00, 0x3C, 0x00, 0x3C, 0x00, 0x3C,
-		0x00, 0x4F, 0x00, 0x62, 0x00, 0x73, 0x00, 0x6F, 0x00, 0x6C,
-		0x00, 0x65, 0x00, 0x74, 0x00, 0x65, 0x00, 0x3E, 0x00, 0x3E,
-		0x00, 0x3E };
-*/
-	char link_data[0x12] = { 0xA2, 0x10, 0x80, 0x0E, 0x00, 0x7A, 0x00, 0x61, 0x00, 0x6B, 0x00, 0x6C, 0x00, 0x65, 0x00, 0x62, 0x00, 0x74 };
-	
-// A2 10 80 0E 00 7A
-// 00 61 00 6B 00 6C 00 65  00 62 00 74 
+	// <<<obsolete>>>: vanila        vv          vv |  value utf-16-bmp, to the end
+	char link_data[0x20] = { 0xA2, 0x1E, 0x80, 0x1C, 0x00, 0x3C, 0x00, 0x3C, 0x00, 0x3C, 0x00, 0x4F, 0x00, 0x62, 0x00, 0x73, 0x00, 0x6F, 0x00, 0x6C, 0x00, 0x65, 0x00, 0x74, 0x00, 0x65, 0x00, 0x3E, 0x00, 0x3E, 0x00, 0x3E };
 	
 	return
 		length + append_to_buffer(sizeof(link_data), link_data);
+	/*/
+	if (!write)
+		return length + 0x12;
+	
+	// zaklebt: hacked catgen        vv          vv |  value utf-16-bmp, to the end
+	char link_data[0x12] = { 0xA2, 0x10, 0x80, 0x0E, 0x00, 0x7A, 0x00, 0x61, 0x00, 0x6B, 0x00, 0x6C, 0x00, 0x65, 0x00, 0x62, 0x00, 0x74 };
+	
+	return
+		length + append_to_buffer(sizeof(link_data), link_data);
+	/**/
 }
 
 int hexdigit(char c)
@@ -764,9 +764,9 @@ int hexdigit(char c)
 
 size_t encode_spc_algo_oid(void *p, bool write)
 {
-	size_t length;
+	size_t length = 0;
 	
-	length = encode_known_oid_with_header(&datacache.oids->spc_algo_oid, write);
+	length += encode_known_oid_with_header(&datacache.oids->spc_algo_oid, write);
 	length += encode_null(write);
 	
 	return length;
@@ -774,11 +774,11 @@ size_t encode_spc_algo_oid(void *p, bool write)
 
 size_t encode_spc_algo(void *p, bool write)
 {
-	struct a_file *f = p;
-	struct octet_string oc = { SHA1_BYTE_LEN, f->sha1_bytes };
+	struct a_file *file = p;
+	struct octet_string oc = { SHA1_BYTE_LEN, file->sha1_bytes };
 	size_t length = 0;
 	
-	length += encode_sequence(f, encode_spc_algo_oid, write);
+	length += encode_sequence(p, encode_spc_algo_oid, write);
 	length += encode_octet_string(&oc, write);
 	
 	return length;
@@ -786,14 +786,10 @@ size_t encode_spc_algo(void *p, bool write)
 
 size_t encode_spc(void *p, bool write)
 {
-	struct a_file *f = p;
-	size_t length;
-
-	if (f->is_link == false) {
-		length = encode_sequence(p, encode_spc_image_data, write);
-	} else {
-		length = encode_sequence(p, encode_spc_link, write);
-	}
+	struct a_file *file = p;
+	size_t length = 0;
+	
+	length += encode_sequence(p, file->is_link? encode_spc_link : encode_spc_image_data, write);
 	length += encode_sequence(p, encode_spc_algo, write);
 
 	return length;
@@ -806,11 +802,10 @@ size_t encode_spc_sequence(void *p, bool write)
 
 size_t encode_spc_oid(void *p, bool write)
 {
-	struct a_file *f = p;
-	size_t length;
+	size_t length = 0;
 	
-	length = encode_known_oid_with_header(&datacache.oids->spc_oid, write);
-	length += encode_set(f, encode_spc_sequence, write);
+	length += encode_known_oid_with_header(&datacache.oids->spc_oid, write);
+	length += encode_set(p, encode_spc_sequence, write);
 	
 	return length;
 }

--- a/generate-cat-file.c
+++ b/generate-cat-file.c
@@ -460,18 +460,18 @@ size_t encode_known_oid_with_header(struct oid_data *oid, bool write)
 	
 	if (oid->bytes == NULL)
 	{
-		// size of this buffer(256 + 4) is based on
+		// size of this buffer(128 + 4) is based on
 		// max length of oid arc in bytes(3 for local encoder) times max known count of arcs(34)
 		// rounded to nearest power of two
 		// plus max length of length value(4 for local encoder)
-		char oid_buf[0x104];
-		size_t data_length = encode_oid_to_cache(oid->string, oid_buf + 4, 0x100);
-		size_t head_length = 1 + encode_length_to_cache(data_length, oid_buf);
-		oid->length = data_length + head_length;
+		char oid_buf[0x84];
+		size_t data_length = encode_oid_to_cache(oid->string, oid_buf + 4, 0x80);
+		size_t head_length = encode_length_to_cache(data_length, oid_buf);
+		oid->length = data_length + head_length + 1;
 		oid->bytes = malloc(oid->length);
 		oid->bytes[0] = OID_TAG;
 		memcpy(oid->bytes + 1, oid_buf, head_length);
-		memcpy(oid->bytes + head_length, oid_buf + 4, data_length);
+		memcpy(oid->bytes + 1 + head_length, oid_buf + 4, data_length);
 	}
 	
 	if (write)


### PR DESCRIPTION
can be applied separately(7706fc0), but recommend on top of `issue_#3` PR

just example with `-1`

`-1` = `1111_1111` `1111_1111` `1111_1111` `1111_1111` in binary

current encoding
make it positive - `0000_0000` `0000_0000` `0000_0000` `0000_0001`
check conditions - single byte
add sign bit - `1000_0001`
store it

[X.690](https://www.itu.int/ITU-T/studygroups/com17/languages/X.690-0207.pdf) states
>8.3.3 The contents octets shall be a two's complement binary number

[wiki](https://en.wikipedia.org/wiki/Two%27s_complement#Procedure) describes verification method
1000_0001 = -(2<sup>7</sup>) + 0 + 0 + 0 + 0 + 0 + 0 + 2<sup>0</sup> = -128 + 1 = `-127` - not exactly, what was encoded
vice versa for `-127` - it will be encoded as `-1`


now fixed version
invert bits - `0000_0000` `0000_0000` `0000_0000` `0000_0000`
check conditions - single byte
store <ins>original</ins> bits - `1111_1111`

<details><summary>edge case examples - <kbd>128</kbd> and <kbd>-128</kbd></summary>

`128` = `0000_0000` `0000_0000` `0000_0000` `1000_0000`
no invertion
check conditions - two bytes
store <ins>original</ins> bits - `0000_0000` + `1000_0000`
check `0000_0000` `1000_0000` = -(0 x 2<sup>15</sup>) + (7 x 0) + 2<sup>7</sup> + (7 x 0) = -0 + 128 = 128

`-128` = `1111_1111` `1111_1111` `1111_1111` `1000_0000`
invert bits - `0000_0000` `0000_0000` `0000_0000` `0111_1111`
check conditions - single byte
store <ins>original</ins> bits - `1000_0000`
check `1000_0000` = -(2<sup>7</sup>) + (7 x 0) = -128

</details>