### PR TITLE
Feature - Ability to specify time or use current

### DIFF
--- a/gencat.sh
+++ b/gencat.sh
@@ -57,7 +57,7 @@
 #     Server_v100_ARM64_24H2 - arm 64-bit Windows Server 2025 (not tested + officially the first ARM64 Server)
 
 function usage_and_exit() {
-	echo Usage: "$0 -o <output-file> [-h <hardware-ids>] [-O OS string] [-A OS attribute string] file1 [ file2 ... ]"
+	echo Usage: "$0 -o <output-file> [-h <hardware-ids>] [-O OS string] [-A OS attribute string] [-T generation-time] file1 [ file2 ... ]"
 	echo See comment inside this .sh file for list of OS string and OS attributes
 	exit 1
 }
@@ -68,9 +68,10 @@ OUTPUT_CAT_FILE=-
 HARDWARE_ID=windrbd
 OS_STRING=7X64,8X64,_v100_X64
 OS_ATTR=2:6.1,2:6.2,2:10.0
+GEN_TIME=230823140713Z
 DRY_RUN=0
 
-args=$( getopt do:h:O:A: $* )
+args=$( getopt do:h:O:A:T: $* )
 if [ $? -ne 0 ]
 then
 	usage_and_exit
@@ -103,6 +104,11 @@ do
 			;;
 		-A)
 			OS_ATTR=$2
+			shift
+			shift
+			;;
+		-T)
+			GEN_TIME=$2
 			shift
 			shift
 			;;
@@ -141,13 +147,13 @@ unset IFS
 
 if [ $DRY_RUN -eq 1 ]
 then
-	echo $EXEC_DIR/generate-cat-file -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]}
+	echo $EXEC_DIR/generate-cat-file -T $GEN_TIME -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]}
 	exit 0
 fi
 
 if [ $OUTPUT_CAT_FILE == '-' ]
 then
-	$EXEC_DIR/generate-cat-file -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]}
+	$EXEC_DIR/generate-cat-file -T $GEN_TIME -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]}
 else
-	$EXEC_DIR/generate-cat-file -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]} > $OUTPUT_CAT_FILE
+	$EXEC_DIR/generate-cat-file -T $GEN_TIME -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]} > $OUTPUT_CAT_FILE
 fi

--- a/gencat.sh
+++ b/gencat.sh
@@ -57,7 +57,7 @@
 #     Server_v100_ARM64_24H2 - arm 64-bit Windows Server 2025 (not tested + officially the first ARM64 Server)
 
 function usage_and_exit() {
-	echo Usage: "$0 -o <output-file> [-h <hardware-ids>] [-O OS string] [-A OS attribute string] [-T generation-time] file1 [ file2 ... ]"
+	echo Usage: "$0 -o <output-file> [-h <hardware-ids>] [-O OS string] [-A OS attribute string] [-T <generation-time>] file1 [ file2 ... ]"
 	echo See comment inside this .sh file for list of OS string and OS attributes
 	exit 1
 }
@@ -68,7 +68,7 @@ OUTPUT_CAT_FILE=-
 HARDWARE_ID=windrbd
 OS_STRING=7X64,8X64,_v100_X64
 OS_ATTR=2:6.1,2:6.2,2:10.0
-GEN_TIME=230823140713Z
+GEN_TIME="-T 230823140713Z"
 DRY_RUN=0
 
 args=$( getopt do:h:O:A:T: $* )
@@ -108,7 +108,7 @@ do
 			shift
 			;;
 		-T)
-			GEN_TIME=$2
+			GEN_TIME="-T $2"
 			shift
 			shift
 			;;
@@ -147,13 +147,13 @@ unset IFS
 
 if [ $DRY_RUN -eq 1 ]
 then
-	echo $EXEC_DIR/generate-cat-file -T $GEN_TIME -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]}
+	echo $EXEC_DIR/generate-cat-file "$GEN_TIME" -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]}
 	exit 0
 fi
 
 if [ $OUTPUT_CAT_FILE == '-' ]
 then
-	$EXEC_DIR/generate-cat-file -T $GEN_TIME -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]}
+	$EXEC_DIR/generate-cat-file "$GEN_TIME" -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]}
 else
-	$EXEC_DIR/generate-cat-file -T $GEN_TIME -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]} > $OUTPUT_CAT_FILE
+	$EXEC_DIR/generate-cat-file "$GEN_TIME" -A $OS_ATTR -O $OS_STRING -h $HARDWARE_IDS ${sorted_images[*]} > $OUTPUT_CAT_FILE
 fi

--- a/generate-cat-file.c
+++ b/generate-cat-file.c
@@ -1035,7 +1035,7 @@ void create_binary_tree(struct pkcs7_toplevel *sdat)
 
 void __attribute((noreturn)) usage_and_exit(void)
 {
-	fprintf(stderr, "Usage: generate_cat_file -h <hardware-ids> [-O OS string] [-A OS attribute string] [-T generation-time] file-with-hash1 [ file-with-hash2 ... ]\n");
+	fprintf(stderr, "Usage: generate_cat_file -h <hardware-ids> [-O OS string] [-A OS attribute string] [-T <generation-time>] file-with-hash1 [ file-with-hash2 ... ]\n");
 	fprintf(stderr, "Generates a Microsoft Security Catalog (\".cat\") file.\n");
 	fprintf(stderr, "hardware-ids is comma separated list\n");
 	fprintf(stderr, "generation-time has the format YYmmddHHMMSSZ, Z is constant, means 0 timezone\n");

--- a/generate-cat-file.c
+++ b/generate-cat-file.c
@@ -5,6 +5,7 @@
 #include <sys/errno.h>
 #include <ctype.h>
 #include <unistd.h>
+#include <time.h>
 
 /* DER encoding */
 
@@ -990,6 +991,8 @@ void free_allocated(struct pkcs7_toplevel *sdat)
 	}
 	
 	
+	free(sdat->data.cert_trust_list.catalog_list_element->a_time);
+	sdat->data.cert_trust_list.catalog_list_element->a_time = NULL;
 	free(sdat->data.cert_trust_list.catalog_list_element);
 }
 
@@ -1032,9 +1035,10 @@ void create_binary_tree(struct pkcs7_toplevel *sdat)
 
 void __attribute((noreturn)) usage_and_exit(void)
 {
-	fprintf(stderr, "Usage: generate_cat_file -h <hardware-ids> [-O OS string] [-A OS attribute string] file-with-hash1 [ file-with-hash2 ... ]\n");
+	fprintf(stderr, "Usage: generate_cat_file -h <hardware-ids> [-O OS string] [-A OS attribute string] [-T generation-time] file-with-hash1 [ file-with-hash2 ... ]\n");
 	fprintf(stderr, "Generates a Microsoft Security Catalog (\".cat\") file.\n");
 	fprintf(stderr, "hardware-ids is comma separated list\n");
+	fprintf(stderr, "generation-time has the format YYmmddHHMMSSZ, Z is constant, means 0 timezone\n");
 	fprintf(stderr, "file-with-hash has the format filename:sha1-hash-in-hex[:PE]\n");
 	fprintf(stderr, "Use osslsigncode to sign it afterwards.\n");
 	exit(1);
@@ -1205,9 +1209,10 @@ int main(int argc, char **argv)
 	char *os_string = "7X64,8X64,_v100_X64";
 	char *os_attr_string = "2:6.1,2:6.2,2:10.0";
 	char *hardware_ids = NULL;
+	char *gen_time = NULL;
 	char c;
 	
-	while ((c = getopt(argc, argv, "h:A:O:")) != -1) {
+	while ((c = getopt(argc, argv, "h:A:O:T:")) != -1) {
 		switch (c) {
 		case 'h':
 			//hardware_ids = strdup(optarg);
@@ -1219,6 +1224,9 @@ int main(int argc, char **argv)
 		case 'O':
 			os_string = optarg;
 			break;
+		case 'T':
+			gen_time = strdup(optarg); //strdup for avoid complications with freeing
+			break;
 		default:
 			usage_and_exit();
 		}
@@ -1226,6 +1234,16 @@ int main(int argc, char **argv)
 	
 	if (argc <= optind || hardware_ids == NULL) {
 		usage_and_exit();
+	}
+	
+	if (gen_time) {
+		if (strlen(gen_time) != 13 || gen_time[12] != 'Z')
+			usage_and_exit();
+	}
+	else {
+		gen_time = malloc(14);
+		time_t t = time(NULL);
+		strftime(gen_time, 14, "%y%m%d%H%M%SZ", gmtime(&t));
 	}
 	
 	parse_hwids_arg(hardware_ids, &hwids);
@@ -1241,7 +1259,7 @@ int main(int argc, char **argv)
 	
 	s.data.an_int = 1;
 	s.data.cert_trust_list.catalog_list_element->a_hash = a_hash;
-	s.data.cert_trust_list.catalog_list_element->a_time = "230823140713Z";
+	s.data.cert_trust_list.catalog_list_element->a_time = gen_time;
 	s.data.cert_trust_list.catalog_list_element->hwids = hwids;
 	s.data.cert_trust_list.catalog_list_element->files = files;
 	s.data.cert_trust_list.catalog_list_element->os_info.data.name = "OS";
@@ -1285,6 +1303,7 @@ int main(int argc, char **argv)
 	datacache.node = root_node; //otherwise, all used nodes except the last one would not be freed
 	free_allocated(&s);
 	root_node = NULL; files = NULL;
+	gen_time = NULL;
 	hwids = NULL;
 	//free(hardware_ids);
 	//hardware_ids = NULL;


### PR DESCRIPTION
`sh` script and program now can accept optional `-T` switch followed by time in format `YYmmddHHMMSSZ` where `Z` is constant and means 0 timezone (UTC-0)
`241210000423Z`

switch is optional and, to preserve current behaviour, time, that was hardcoded, moved to `sh` script as default/fallback value

note: `sh` script not tested on live system, only some constructions, used in it, in online compilers

note: this feature assumed to be the first for the merging, but not necessary. On merging after GUID feature there expected few conflicts, be careful with `getopt do:h:O:A:` lines