### PR TITLE
Feature - Optional compatibility with ming-win and windows

### DIFF
--- a/generate-cat-file.c
+++ b/generate-cat-file.c
@@ -14,10 +14,6 @@
 	#include <io.h>
 	
 	#define IS_WINDOWS
-	
-	#ifdef _O_BINARY
-		#define HAVE_SETMODE
-	#endif
 #endif
 
 
@@ -1201,6 +1197,17 @@ int parse_hwids_arg(char *hwids, struct list_node **hwid)
 
 int main(int argc, char **argv)
 {
+#ifdef IS_WINDOWS
+	#ifdef _O_BINARY
+	if (_setmode(_fileno(stdout), _O_BINARY) == -1)
+	#endif
+	{
+		fatal("cannot set binary mode for stdout\noperation canceled due to translation(known \"corruption\" in text mode)\nhttps://stackoverflow.com/a/5537079");
+	}
+	
+#endif /* IS_WINDOWS */
+	
+	
 	struct pkcs7_toplevel s = { 0 };
 	struct known_oids oids = { 0 };
 	
@@ -1303,16 +1310,6 @@ int main(int argc, char **argv)
 	hwids = NULL;
 	//free(hardware_ids);
 	//hardware_ids = NULL;
-	
-#ifdef IS_WINDOWS
-	#ifdef HAVE_SETMODE
-	if (_setmode(_fileno(stdout), _O_BINARY) == -1)
-		fatal("cannot set binary mode for stdout\noutput canceled due to translation(known \"corruption\" in text mode)\nhttps://stackoverflow.com/a/5537079");
-	#else
-	freopen("CON", "wb", stdout);
-	//stdout = fdopen(STDOUT_FILENO, "wb");
-	#endif
-#endif
 	
 	/* and write to stdout or so ... */
 	fwrite(buffer, buflen, 1, stdout);

--- a/strip-pe-image.c
+++ b/strip-pe-image.c
@@ -9,10 +9,6 @@
 	#include <io.h>
 
 	#define IS_WINDOWS
-
-	#ifdef _O_BINARY
-		#define HAVE_SETMODE
-	#endif
 #endif
 
 char *read_file(const char *fname, long *size_return)
@@ -22,20 +18,21 @@ char *read_file(const char *fname, long *size_return)
 	FILE *f;
 
 #ifdef IS_WINDOWS
-	#ifdef HAVE_SETMODE
+	#ifdef _O_BINARY
 	if (_setmode(_fileno(stdout), _O_BINARY) == -1)
+	#endif
 	{
-		fprintf(stderr, "cannot set binary mode for stdout\noutput canceled due to translation(known \"corruption\" in text mode)\nhttps://stackoverflow.com/a/5537079");
+		fprintf(stderr, "cannot set binary mode for stdout\noperation canceled due to translation(known \"corruption\" in text mode)\nhttps://stackoverflow.com/a/5537079");
 		exit(1);
 	}
-	#else
-	freopen("CON", "wb", stdout);
-	//stdout = fdopen(STDOUT_FILENO, "wb");
-	#endif
 	f = fopen(fname, "rb");
-#else
+
+#else  /* not IS_WINDOWS */
+
 	f = fopen(fname, "r");
-#endif
+
+#endif /* IS_WINDOWS */
+
 
 	if (f == NULL) {
 		perror("opening image file");

--- a/strip-pe-image.c
+++ b/strip-pe-image.c
@@ -4,13 +4,39 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#if defined(_WINDOWS) || defined(_WIN32) || defined(WIN32)
+	#include <fcntl.h>
+	#include <io.h>
+
+	#define IS_WINDOWS
+
+	#ifdef _O_BINARY
+		#define HAVE_SETMODE
+	#endif
+#endif
+
 char *read_file(const char *fname, long *size_return)
 {
 	char *buffer;
 	long file_size;
 	FILE *f;
 
+#ifdef IS_WINDOWS
+	#ifdef HAVE_SETMODE
+	if (_setmode(_fileno(stdout), _O_BINARY) == -1)
+	{
+		fprintf(stderr, "cannot set binary mode for stdout\noutput canceled due to translation(known \"corruption\" in text mode)\nhttps://stackoverflow.com/a/5537079");
+		exit(1);
+	}
+	#else
+	freopen("CON", "wb", stdout);
+	//stdout = fdopen(STDOUT_FILENO, "wb");
+	#endif
+	f = fopen(fname, "rb");
+#else
 	f = fopen(fname, "r");
+#endif
+
 	if (f == NULL) {
 		perror("opening image file");
 		return NULL;


### PR DESCRIPTION
allow compilation with ming-win, proper file reading and stdout redirect on windows

pure optional for such folks as me and can be rejected :D

issue with `sys/errno.h` - usual location is just `errno.h` (not only on windows)
issue with file reading and stdout redirect - [windows text mode translation](https://stackoverflow.com/a/5537079)

no conflicts expected