### PR TITLE
fix issue #15 and few other

### DIFF
--- a/gencat.sh
+++ b/gencat.sh
@@ -65,7 +65,7 @@ function usage_and_exit() {
 EXEC_DIR=$( dirname $0 )
 
 OUTPUT_CAT_FILE=-
-HARDWARE_ID=windrbd
+HARDWARE_IDS=windrbd
 OS_STRING=7X64,8X64,_v100_X64
 OS_ATTR=2:6.1,2:6.2,2:10.0
 GEN_TIME="-T 230823140713Z"

--- a/generate-cat-file.c
+++ b/generate-cat-file.c
@@ -1189,7 +1189,7 @@ void parse_file_args(char **f_args, int f_count, char *os_attr, struct list_node
 	hwid_data->value = hwid_begin; \
 }
 
-//note: it does modify hwids content (replace comma with null) and creates references to its particular parts
+//note: it does modify hwids content (replace each comma, that comes 1st after hwid, with null) and creates references to its particular parts
 int parse_hwids_arg(char *hwids, struct list_node **hwid)
 {
 	struct list_node *hwid_last = NULL;
@@ -1199,13 +1199,17 @@ int parse_hwids_arg(char *hwids, struct list_node **hwid)
 	
 	while (*hwids)
 	{
-		if (*hwids == ',' && hwids > hwid_begin)
+		if (*hwids == ',')
 		{
-			FUNC_CREATE_HWID_NODE();
-			
-			//"cut" string to current hwid end
-			*hwids = '\0';
-			//update current position and move position of current hwid begin to it
+			//check if delimiter is NOT immediately after another one (empty entries must be skipped, delimiter is not allowed in the value)
+			if (hwids > hwid_begin)
+			{
+				FUNC_CREATE_HWID_NODE();
+				
+				//"cut" string to current hwid end
+				*hwids = '\0';
+			}
+			//update current position AND move position of current hwid begin to it
 			hwid_begin = ++hwids;
 		}
 		else

--- a/generate-cat-file.c
+++ b/generate-cat-file.c
@@ -1088,7 +1088,7 @@ void parse_file_args(char **f_args, int f_count, char *os_attr, struct list_node
 	struct list_node *this_file;
 	struct a_file *file_data;
 	int fname_len;
-	bool is_pe = false;
+	bool is_pe;
 	
 	*file = NULL;
 	
@@ -1123,6 +1123,8 @@ void parse_file_args(char **f_args, int f_count, char *os_attr, struct list_node
 			
 			is_pe = true;
 		}
+		else
+			is_pe = false;
 		
 		this_file = malloc(sizeof(struct list_node) + sizeof(struct a_file));
 		if (this_file == NULL) {
@@ -1164,10 +1166,6 @@ void parse_file_args(char **f_args, int f_count, char *os_attr, struct list_node
 	/*create new struct and chain it with previouse
 	//reverse order is based on observed cat files */ \
 	*hwid = malloc(sizeof(struct list_node) + sizeof(struct an_attribute_data)); \
-	if (*hwid == NULL) \
-	{ \
-	    fatal(ERR_OOM); \
-	} \
 	if (*hwid == NULL) \
 	{ \
 		fatal(ERR_OOM); \


### PR DESCRIPTION
\- partial revert of d94ead34f504507ffd7c49b598995a77a951b385
\- remove double OOM check (ace9bbf25a0c0db899e750ac97d33212276fcc1f)
\- fix typo in `.sh`, that leads to incorrect `.cat` file (74c1009f1baf1bc7ff67f03e2cee4b19efc73151 and ef3145891c065a415cca8d6b3aa54429b4bcc767 are from parallel features, branched from f6a3c0f608ff1fd7e56b932140ea600fae9d77cb; 1st did not change problematic line, but 2nd did; there was conflict between them resolved as 5db4e1ab03ff716f1476f88f556e4c2f1bdf29ca)
\- fix bug in hwids parser on specific input; looks like i was aware of the root issue, but solve it not fully(correctly)